### PR TITLE
fix(tools): spectate_map_gui no longer incorrectly persists the "recent" selection after selecting a new test (fixes #34)

### DIFF
--- a/python_helper_scripts/spectate_map/spectate_map.py
+++ b/python_helper_scripts/spectate_map/spectate_map.py
@@ -315,6 +315,20 @@ def on_test_selected(event=None):
 
     select_filename(filename)
 
+    #
+    # `on_recent_selected` mirrors its pick into this list, so only drop the
+    # recent highlight once the two lists actually disagree.
+    #
+
+    recent_selection = recent_listbox.curselection()
+
+    if recent_selection:
+
+        recent_filename = state["settings"]["recent"][recent_selection[0]]
+
+        if recent_filename != filename:
+            recent_listbox.selection_clear(0, tk.END)
+
 
 def on_recent_selected(event=None):
 
@@ -431,6 +445,11 @@ def create_gui():
 
     scrollbar.pack(side="right", fill="y")
     tests_listbox.pack(side="left", fill="both", expand=True)
+
+    tests_listbox.bind(
+        "<<ListboxSelect>>",
+        on_test_selected,
+    )
 
     #
     # Recent

--- a/python_helper_scripts/spectate_map/spectate_map.py
+++ b/python_helper_scripts/spectate_map/spectate_map.py
@@ -265,6 +265,29 @@ def update_filter(*args):
         ]
 
     refresh_tests_list()
+
+    #
+    # `refresh_tests_list` wipes the highlight, so re-apply it to the cached
+    # selection. A selection the search has hidden is dropped instead: running
+    # it would launch a test that is no longer anywhere in the list.
+    #
+
+    if state["selected"] is not None:
+
+        if state["selected"] in state["filtered_tests"]:
+
+            if tests_listbox is not None:
+                index = state["filtered_tests"].index(state["selected"])
+                tests_listbox.selection_set(index)
+                tests_listbox.see(index)
+
+        else:
+
+            select_filename(None)
+
+            if recent_listbox is not None:
+                recent_listbox.selection_clear(0, tk.END)
+
     set_status(f"{len(state['filtered_tests'])} matching tests")
 
 

--- a/python_helper_scripts/spectate_map/spectate_map.py
+++ b/python_helper_scripts/spectate_map/spectate_map.py
@@ -339,19 +339,33 @@ def on_recent_selected(event=None):
 
     filename = state["settings"]["recent"][selection[0]]
 
-    if filename in state["all_tests"]:
+    if filename not in state["all_tests"]:
 
-        select_filename(filename)
+        #
+        # The file has gone from the tests folder. Drop the selection rather
+        # than leaving the previous pick cached, which would quietly run that
+        # earlier test instead.
+        #
 
-        search_var.set("")
+        select_filename(None)
 
-        try:
-            index = state["filtered_tests"].index(filename)
-            tests_listbox.selection_clear(0, tk.END)
-            tests_listbox.selection_set(index)
-            tests_listbox.see(index)
-        except ValueError:
-            pass
+        tests_listbox.selection_clear(0, tk.END)
+
+        set_status(f"{filename} is no longer in the tests folder")
+
+        return
+
+    select_filename(filename)
+
+    search_var.set("")
+
+    try:
+        index = state["filtered_tests"].index(filename)
+        tests_listbox.selection_clear(0, tk.END)
+        tests_listbox.selection_set(index)
+        tests_listbox.see(index)
+    except ValueError:
+        pass
 
 
 # =============================================================================


### PR DESCRIPTION
`get_selected_filename` returns the cached `state["selected"]` whenever it is set, but nothing kept that cache in step with the two listboxes or the search filter. Three ways it went stale, each of which launched a test the user had not picked — one commit per fix:

- **Clicking the main list after the recents list did nothing** (the reported bug). `on_test_selected` was defined but never bound, so the tests listbox only reacted to a double-click; once a recents entry had pinned the cache, single-clicking a different test left it untouched and "Run Selected" launched the recents file. Bind `<<ListboxSelect>>` on the tests listbox, and clear the recents highlight once the two lists disagree so only one entry ever looks selected.
- **A recents entry whose file is gone ran the previous pick.** Clicking one hit the `filename in state["all_tests"]` guard and returned silently, leaving the earlier selection cached. It now drops the selection, clears the highlight and says so in the status bar, so running warns instead of quietly starting a different test.
- **Searching did not drop a hidden selection.** Typing a filter that hid the selected test left it cached with no highlight on screen, so "Run Selected" launched something no longer in the list. `update_filter` now re-applies the highlight when the selection is still visible and drops it when it is not.

The highlight `on_recent_selected` mirrors into the tests listbox is deliberately left alone: Tk fires `<<ListboxSelect>>` for programmatic selection changes too, so the recents highlight is compared by filename rather than cleared unconditionally, which would make it flash off the moment it was clicked.

Not verified by running the GUI — `tkinter` is not available in the environment this was written in and cannot be installed there, so the event paths were traced by hand (including the case where the mirrored `selection_set` does *not* fire the virtual event, where the fix still holds). Worth a quick click-through on Windows before merging.

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138mF5ac4DBgtwYmKfT4Vub

---
_Generated by [Claude Code](https://claude.ai/code/session_0138mF5ac4DBgtwYmKfT4Vub)_